### PR TITLE
Refactoring

### DIFF
--- a/include/task_graph.hrl
+++ b/include/task_graph.hrl
@@ -2,10 +2,10 @@
 -define(_TASK_GRAPH_HRL_, true).
 
 -record(tg_task,
-        { id             :: task_graph_lib:task_id()
-        , execute        :: task_graph_lib:task_execute()
+        { id             :: task_graph:task_id()
+        , execute        :: task_graph:task_execute()
         , data           :: term()
-        , resources = [] :: [task_graph_lib:resource_id()]
+        , resources = [] :: [task_graph:resource_id()]
         }).
 
 -record(tg_event,

--- a/src/task_graph.erl
+++ b/src/task_graph.erl
@@ -1,6 +1,6 @@
+%%% @doc Main interface for the Task Graph library
+%%%
 -module(task_graph).
-
--behaviour(gen_server).
 
 -include("task_graph_int.hrl").
 
@@ -9,17 +9,26 @@
         , run_graph/2
         ]).
 
-%% gen_server callbacks
--export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
 
--type worker_state() :: term().
+-export_type([ task/0
+             , digraph/0
+             , task_id/0
+             , resource_id/0
+             , task_execute/0
+             , maybe/1
+             ]).
 
--type event_mgr() :: atom()
-                   | {atom(), atom()}
-                   | {global, term()}
-                   | pid()
-                   | undefined.
+-type task_execute() :: atom() | task_runner:run().
+
+-type task_id() :: term().
+
+-type task() :: #tg_task{}.
+
+-type resource_id() :: atom() | number() | reference() | list().
+
+-type maybe(A) :: {just, A} | undefined.
+
+-type digraph() :: {[task()], [{task_id(), task_id()}]}.
 
 -type settings_key() :: event_manager
                       | event_handlers
@@ -27,419 +36,48 @@
                       | disable_guards
                       .
 
--record(worker_pool,
-        { workers :: #{pid() => worker_state()}
-        , cap :: non_neg_integer() | unlimited
-        }).
-
--record(state,
-        { graph                            :: task_graph_lib:graph()
-        , event_mgr                        :: event_mgr()
-        , current_tasks = #{}              :: #{task_graph_lib:task_id() => pid()}
-        , failed_tasks = #{}               :: #{task_graph_lib:task_id() => term()}
-        , workers                          :: #{task_graph_lib:task_execute() =>
-                                                    #worker_pool{}}
-        , parent                           :: pid()
-        , guards                           :: boolean()
-        }).
-
-%%%===================================================================
-%%% API
-%%%===================================================================
-
 %%--------------------------------------------------------------------
-%% @doc
-%% @end
+%% @doc Execute task graph with default settings
+%% @see run_graph/3
 %%--------------------------------------------------------------------
 -spec run_graph( atom()
-               , task_manager_lib:tasks()
+               , task_graph:digraph()
                ) -> {ok, term()} | {error, term()}.
-run_graph(TaskName, Tasks) ->
-    run_graph(TaskName, #{}, Tasks).
+run_graph(Name, Tasks) ->
+    run_graph(Name, #{}, Tasks).
 
+%%--------------------------------------------------------------------
+%% @doc Execute a task graph. `Name' is an unique identifier of the
+%% process executing task graph.
+%%
+%% `Settings' is a map that may contain the following elements:
+%%
+%%    `event_manager' is pid of a process receiving `tg_event's. By
+%%    default there is no event manager. `tg_events' are useful for
+%%    progress tracking and profiling
+%%
+%%    `event_handlers' is a list of 2-tuples containing gen_event
+%%    handler module and its initial state. Task graph will start a
+%%    new gen_event process with these handlers. Note that only one
+%%    event handler is supported at time. `event_manager' parameter
+%%    takes precedence over `event_handlers'.
+%%
+%%    `resources' is a map containing resource limits. By default all
+%%    resources are unlimited.
+%%
+%%    `disable_guards' is a boolean flag that forces execution of all
+%%    tasks. (Similar to ```make -B``` flag)
+%%
+%% `Tasks' is a 2-tuple containing vertices and edges of the task
+%% graph, respectively. Vertices are represented by a list of
+%% ```#tg_task{}``` records. Task ids should be unique. Edges is a
+%% list of 2-tuples where first element blocks execution of the second
+%% one.
+%%
+%%--------------------------------------------------------------------
 -spec run_graph( atom()
                , #{settings_key() => term()}
-               , task_manager_lib:tasks()
+               , task_graph:digraph()
                ) -> {ok, term()} | {error, term()}.
-run_graph(TaskName, Settings, Tasks) ->
-    case maps:get(event_manager, Settings, undefined) of
-        EventMgr when is_pid(EventMgr) ->
-            ok;
-        undefined ->
-            {ok, EventMgr} = gen_event:start_link(),
-            lists:foreach( fun({Handler, Args}) ->
-                                   gen_event:add_handler(EventMgr, Handler, Args)
-                           end
-                         , maps:get(event_handlers, Settings, [])
-                         )
-    end,
-    Ret = gen_server:start( {local, TaskName}
-                          , ?MODULE
-                          , {TaskName, EventMgr, Settings, Tasks, self()}
-                          , []
-                          ),
-    case Ret of
-        {ok, Pid} ->
-            Ref = monitor(process, Pid),
-            receive
-                {result, Pid, Result} ->
-                    gen_event:stop(EventMgr, normal, infinity),
-                    %% Make sure the server terminated:
-                    receive
-                        {'DOWN', Ref, process, Pid, _} ->
-                            ok
-                    after 1000 ->
-                            %% Should not happen
-                            exit(Pid, kill),
-                            error({timeout_waiting_for, Pid})
-                    end,
-                    Result;
-                {'DOWN', Ref, process, Pid, Reason} ->
-                    {error, {internal_error, Reason}}
-            end;
-        Err ->
-            Err
-    end.
-
-%%%===================================================================
-%%% gen_server callbacks
-%%%===================================================================
-
-init({TaskName, EventMgr, Settings, Tasks, Parent}) ->
-    ResourceLimits = maps:get(resources, Settings, #{}),
-    Graph = task_graph_lib:new_graph(TaskName, ResourceLimits),
-    try
-        ok = push_tasks(Tasks, Graph, EventMgr, undefined),
-        %% io:format(user, "~s~n", [task_graph_lib:print_graph(Graph2)]),
-        maybe_pop_tasks(),
-        {ok, #state{ graph = Graph
-                   , workers = #{}
-                   , event_mgr = EventMgr
-                   %% , result = #{}
-                   , parent = Parent
-                   , guards = not maps:get(disable_guards, Settings, false)
-                   }}
-    catch
-        _:{badmatch,{error, circular_dependencies, Cycle}} ->
-            {stop, {topology_error, Cycle}}
-    end.
-
-handle_call(_Request, _From, State) ->
-    Reply = ok,
-    {reply, Reply, State}.
-
-handle_cast({complete_task, Ref, _Success = false, _Changed, Return, _}, State) ->
-    maybe_pop_tasks(),
-    {noreply, push_error(Ref, Return, State)};
-handle_cast({complete_task, Ref, _Success = true, Changed, Return, NewTasks}, State) ->
-    #state{ graph = G
-          } = State,
-    event(complete_task, Ref, State),
-    ok = task_graph_lib:complete_task(G, Ref, Changed, Return),
-    State1 =
-        case push_tasks(NewTasks, State#state{graph = G}, undefined) of
-            ok ->
-                State#state{ current_tasks =
-                                 maps:remove(Ref, State#state.current_tasks)
-                           };
-            Err ->
-                %% Dynamically added tasks are malformed or break the topology
-                push_error(Ref, Err, State)
-        end,
-    maybe_pop_tasks(),
-    {noreply, State1};
-handle_cast({defer_task, Ref, NewTasks}, State) ->
-    #state{ current_tasks = Curr
-          } = State,
-    event(defer_task, Ref, State),
-    State1 =
-        case push_tasks(NewTasks, State, {just, Ref}) of
-            ok ->
-                State#state{ current_tasks = map_sets:del_element(Ref, Curr)
-                           };
-            Err ->
-                push_error(Ref, Err, State)
-        end,
-    maybe_pop_tasks(),
-    {noreply, State1};
-handle_cast(maybe_pop_tasks, State) ->
-    #state{ graph = G
-          , current_tasks = CurrentlyRunningTasks
-          } = State,
-    event(shed_begin, State),
-    case is_success(State) of
-        true ->
-            %% There are no failed tasks, proceed
-            {ok, Tasks} = task_graph_lib:pre_schedule_tasks( G
-                                                           , CurrentlyRunningTasks
-                                                           );
-        false ->
-            %% Something's failed, don't schedule new tasks
-            Tasks = []
-    end,
-    event(shed_end, State),
-    case Tasks of
-        [] ->
-            case is_complete(State) of
-                true ->
-                    %% Task graph
-                    complete_graph(State);
-                false ->
-                    %% All tasks have unresolved dependencies, wait
-                    {noreply, State}
-            end;
-        _ ->
-            %% Schedule new tasks
-            State2 = lists:foldl( fun run_task/2
-                                , State
-                                , Tasks
-                                ),
-            {noreply, State2}
-    end.
-
-handle_info(_Info, State) ->
-    {noreply, State}.
-
-terminate(_Reason, State) ->
-    task_graph_lib:delete_graph(State#state.graph),
-    ok.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
-
-%%%===================================================================
-%%% Internal functions
-%%%===================================================================
-
--spec push_tasks( task_graph_lib:tasks()
-                , #state{}
-                , task_graph_lib:maybe(task_graph_lib:task_id())
-                ) -> ok
-                   | {error, term()}.
-push_tasks(NewTasks, #state{graph = G, event_mgr = EventMgr}, Parent) ->
-    push_tasks(NewTasks, G, EventMgr, Parent).
-
-push_tasks({[], []}, _Graph, _, _) ->
-    ok;
-push_tasks(NewTasks = {Vertices, Edges}, G, EventMgr, Parent) ->
-    event(extend_begin, EventMgr),
-    event(add_tasks, Vertices, EventMgr),
-    event(add_dependencies, Edges, EventMgr),
-    Ret = task_graph_lib:expand(G, NewTasks, Parent),
-    event(extend_end, EventMgr),
-    Ret.
-
-event(A, B) ->
-    event(A, undefined, B).
-event(Kind, Data, #state{event_mgr = EventMgr}) ->
-    event(Kind, Data, EventMgr);
-event(Kind, Data, EventMgr) when is_pid(EventMgr) ->
-    gen_event:notify( EventMgr
-                    , #tg_event{ timestamp = erlang:system_time(?tg_timeUnit)
-                               , kind = Kind
-                               , data = Data
-                               }
-                    ).
-
-complete_graph(State = #state{parent = Pid, failed_tasks = Failed}) ->
-    %% Assert:
-    #{} = State#state.current_tasks,
-    Result = case is_success(State) of
-                 true ->
-                     {ok, Failed};
-                 false ->
-                     {error, Failed}
-             end,
-    event(graph_complete, [self(), Result], State),
-    Pid ! {result, self(), Result},
-    {stop, normal, State}.
-
-is_success(State) ->
-    maps:size(State#state.failed_tasks) == 0.
-
-is_complete(State) ->
-    maps:size(State#state.current_tasks) == 0.
-
-push_error(Ref, Error, State) ->
-    OldFailedTasks = State#state.failed_tasks,
-    OldCurrentTasks = State#state.current_tasks,
-    event(task_failed, [Ref, Error], State),
-    State#state{ failed_tasks = OldFailedTasks#{Ref => Error}
-               , current_tasks = maps:remove(Ref, OldCurrentTasks)
-               }.
-
-maybe_pop_tasks() ->
-    gen_server:cast(self(), maybe_pop_tasks).
-
--spec complete_task( pid()
-                   , task_graph_lib:task_id()
-                   , boolean()
-                   , boolean()
-                   , term()
-                   , task_graph_lib:tasks()
-                   ) -> ok.
-complete_task(Parent, Ref, Success, Changed, Return, NewTasks) ->
-    gen_server:cast(Parent, {complete_task, Ref, Success, Changed, Return, NewTasks}).
-
--spec complete_task(pid(), task_graph_lib:task_id(), boolean(), boolean(), term()) -> ok.
-complete_task(Parent, Ref, Success, Changed, Return) ->
-    complete_task(Parent, Ref, Success, Changed, Return, {[], []}).
-
--spec defer_task(pid(), task_graph_lib:task_id(), task_graph_lib:tasks()) -> ok.
-defer_task(Parent, Ref, NewTasks) ->
-    gen_server:cast(Parent, {defer_task, Ref, NewTasks}).
-
--spec run_task({task_graph_lib:task(), boolean()}, #state{}) -> #state{}.
-run_task( {Task = #tg_task{id = Ref}, DepsUnchanged}
-        , State = #state{ current_tasks = TT
-                        , graph = G
-                        , guards = Guards
-                        }) ->
-    GetDepResult = fun(Ref1) ->
-                           task_graph_lib:get_task_result(G, Ref1)
-                   end,
-    Pid = spawn_task( Task
-                    , State#state.event_mgr
-                    , GetDepResult
-                    , DepsUnchanged andalso Guards
-                    ),
-    State#state{current_tasks = TT#{Ref => Pid}}.
-
--spec spawn_task( task_graph_lib:task()
-                , event_mgr()
-                , fun((task_graph_lib:task_id()) -> {ok, term()} | error)
-                , boolean()
-                ) -> pid().
-spawn_task( Task = #tg_task{ id = Ref
-                           , execute = Exec
-                           }
-          , EventMgr
-          , GetDepResult
-          , DepsUnchanged
-          ) ->
-    Parent = self(),
-    case Exec of
-        _ when is_atom(Exec) ->
-            RunTaskFun = fun Exec:run_task/3,
-            GuardFun   = fun Exec:guard/3;
-        _ when is_function(Exec) ->
-            RunTaskFun = Exec,
-            GuardFun   = fun(_, _, _) -> changed end;
-        {RunTaskFun, GuardFun} when is_function(RunTaskFun)
-                                  , is_function(GuardFun) ->
-            ok;
-        _ ->
-            RunTaskFun = undefined, %% D'oh!
-            GuardFun = undefined,
-            error({badtask, Exec})
-    end,
-    spawn_link(
-      fun() ->
-              try
-                  Unchanged = DepsUnchanged andalso do_run_guard( Parent
-                                                                , EventMgr
-                                                                , GuardFun
-                                                                , Task
-                                                                , GetDepResult
-                                                                ),
-                  if Unchanged ->
-                          ok;
-                     true ->
-                          do_run_task( Parent
-                                     , EventMgr
-                                     , RunTaskFun
-                                     , Task
-                                     , GetDepResult
-                                     )
-                  end
-              catch
-                  _:Err ?BIND_STACKTRACE(Stack) ->
-                      ?GET_STACKTRACE(Stack),
-                      complete_task( Parent
-                                   , Ref
-                                   , _success = false
-                                   , _changed = true
-                                   , {uncaught_exception, Err, Stack}
-                                   )
-              end
-      end).
-
--spec do_run_guard( pid()
-                  , pid()
-                  , fun()
-                  , task_graph_lib:task()
-                  , task_runner:get_deps_result()
-                  ) -> boolean().
-do_run_guard( Parent
-            , EventMgr
-            , GuardFun
-            , #tg_task{ id = Ref
-                      , data = Data
-                      }
-            , GetDepResult
-            ) ->
-    event(run_guard, Ref, EventMgr),
-    Result = GuardFun(Ref, Data, GetDepResult),
-    event(guard_complete, Ref, EventMgr),
-    case Result of
-        unchanged ->
-            complete_task(Parent, Ref, true, false, undefined),
-            true;
-        {unchanged, Return} ->
-            complete_task(Parent, Ref, true, false, Return),
-            true;
-        changed ->
-            false
-    end.
-
--spec do_run_task( pid()
-                 , pid()
-                 , fun()
-                 , task_graph_lib:task()
-                 , task_runner:get_deps_result()
-                 ) -> ok.
-do_run_task( Parent
-           , EventMgr
-           , RunTaskFun
-           , #tg_task{ id = Ref
-                     , data = Data
-                     }
-           , GetDepResult
-           ) ->
-    event(spawn_task, Ref, EventMgr),
-    Return = RunTaskFun(Ref, Data, GetDepResult),
-    case Return of
-        ok ->
-            complete_task( Parent
-                         , Ref
-                         , _success = true
-                         , _changed = true
-                         , undefined
-                         );
-        {ok, Result} ->
-            complete_task( Parent
-                         , Ref
-                         , _success = true
-                         , _changed = true
-                         , Result
-                         );
-        {ok, Result, NewTasks} ->
-            complete_task( Parent
-                         , Ref
-                         , _success = true
-                         , _changed = true
-                         , Result
-                         , NewTasks
-                         );
-
-        {defer, NewTasks} ->
-            defer_task(Parent, Ref, NewTasks);
-
-        {error, Reason} ->
-            complete_task( Parent
-                         , Ref
-                         , _success = false
-                         , _changed = true
-                         , Reason
-                         )
-    end.
+run_graph(Name, Settings, Tasks) ->
+    task_graph_server:run_graph(Name, Settings, Tasks).

--- a/src/task_graph_server.erl
+++ b/src/task_graph_server.erl
@@ -1,0 +1,421 @@
+-module(task_graph_server).
+
+-behaviour(gen_server).
+
+-include("task_graph_int.hrl").
+
+%% API
+-export([ run_graph/3
+        ]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-record(state,
+        { graph                            :: task_graph_digraph:digraph()
+        , event_mgr                        :: event_mgr()
+        , current_tasks = #{}              :: #{task_graph:task_id() => pid()}
+        , failed_tasks = #{}               :: #{task_graph:task_id() => term()}
+        , parent                           :: pid()
+        , guards                           :: boolean()
+        }).
+
+-type event_mgr() :: atom()
+                   | {atom(), atom()}
+                   | {global, term()}
+                   | pid()
+                   | undefined.
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec run_graph( atom()
+               , #{task_graph:settings_key() => term()}
+               , task_graph:digraph()
+               ) -> {ok, term()} | {error, term()}.
+run_graph(TaskName, Settings, Tasks) ->
+    case maps:get(event_manager, Settings, undefined) of
+        EventMgr when is_pid(EventMgr) ->
+            ok;
+        undefined ->
+            {ok, EventMgr} = gen_event:start_link(),
+            lists:foreach( fun({Handler, Args}) ->
+                                   gen_event:add_handler(EventMgr, Handler, Args)
+                           end
+                         , maps:get(event_handlers, Settings, [])
+                         )
+    end,
+    Ret = gen_server:start( {local, TaskName}
+                          , ?MODULE
+                          , {TaskName, EventMgr, Settings, Tasks, self()}
+                          , []
+                          ),
+    case Ret of
+        {ok, Pid} ->
+            Ref = monitor(process, Pid),
+            receive
+                {result, Pid, Result} ->
+                    gen_event:stop(EventMgr, normal, infinity),
+                    %% Make sure the server terminated:
+                    receive
+                        {'DOWN', Ref, process, Pid, _} ->
+                            ok
+                    after 1000 ->
+                            %% Should not happen
+                            exit(Pid, kill),
+                            error({timeout_waiting_for, Pid})
+                    end,
+                    Result;
+                {'DOWN', Ref, process, Pid, Reason} ->
+                    {error, {internal_error, Reason}}
+            end;
+        Err ->
+            Err
+    end.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init({TaskName, EventMgr, Settings, Tasks, Parent}) ->
+    ResourceLimits = maps:get(resources, Settings, #{}),
+    Graph = task_graph_digraph:new_graph(TaskName, ResourceLimits),
+    try
+        ok = push_tasks(Tasks, Graph, EventMgr, undefined),
+        %% io:format(user, "~s~n", [task_graph_digraph:print_graph(Graph2)]),
+        maybe_pop_tasks(),
+        {ok, #state{ graph = Graph
+                   , event_mgr = EventMgr
+                   , parent = Parent
+                   , guards = not maps:get(disable_guards, Settings, false)
+                   }}
+    catch
+        _:{badmatch,{error, circular_dependencies, Cycle}} ->
+            {stop, {topology_error, Cycle}}
+    end.
+
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+handle_cast({complete_task, Ref, _Success = false, _Changed, Return, _}, State) ->
+    maybe_pop_tasks(),
+    {noreply, push_error(Ref, Return, State)};
+handle_cast({complete_task, Ref, _Success = true, Changed, Return, NewTasks}, State) ->
+    #state{ graph = G
+          } = State,
+    event(complete_task, Ref, State),
+    ok = task_graph_digraph:complete_task(G, Ref, Changed, Return),
+    State1 =
+        case push_tasks(NewTasks, State#state{graph = G}, undefined) of
+            ok ->
+                State#state{ current_tasks =
+                                 maps:remove(Ref, State#state.current_tasks)
+                           };
+            Err ->
+                %% Dynamically added tasks are malformed or break the topology
+                push_error(Ref, Err, State)
+        end,
+    maybe_pop_tasks(),
+    {noreply, State1};
+handle_cast({defer_task, Ref, NewTasks}, State) ->
+    #state{ current_tasks = Curr
+          } = State,
+    event(defer_task, Ref, State),
+    State1 =
+        case push_tasks(NewTasks, State, {just, Ref}) of
+            ok ->
+                State#state{ current_tasks = map_sets:del_element(Ref, Curr)
+                           };
+            Err ->
+                push_error(Ref, Err, State)
+        end,
+    maybe_pop_tasks(),
+    {noreply, State1};
+handle_cast(maybe_pop_tasks, State) ->
+    #state{ graph = G
+          , current_tasks = CurrentlyRunningTasks
+          } = State,
+    event(shed_begin, State),
+    case is_success(State) of
+        true ->
+            %% There are no failed tasks, proceed
+            {ok, Tasks} = task_graph_digraph:pre_schedule_tasks( G
+                                                               , CurrentlyRunningTasks
+                                                               );
+        false ->
+            %% Something's failed, don't schedule new tasks
+            Tasks = []
+    end,
+    event(shed_end, State),
+    case Tasks of
+        [] ->
+            case is_complete(State) of
+                true ->
+                    %% Task graph
+                    complete_graph(State);
+                false ->
+                    %% All tasks have unresolved dependencies, wait
+                    {noreply, State}
+            end;
+        _ ->
+            %% Schedule new tasks
+            State2 = lists:foldl( fun run_task/2
+                                , State
+                                , Tasks
+                                ),
+            {noreply, State2}
+    end.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, State) ->
+    task_graph_digraph:delete_graph(State#state.graph),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+-spec push_tasks( task_graph:digraph()
+                , #state{}
+                , task_graph:maybe(task_graph:task_id())
+                ) -> ok
+                   | {error, term()}.
+push_tasks(NewTasks, #state{graph = G, event_mgr = EventMgr}, Parent) ->
+    push_tasks(NewTasks, G, EventMgr, Parent).
+
+push_tasks({[], []}, _Graph, _, _) ->
+    ok;
+push_tasks(NewTasks = {Vertices, Edges}, G, EventMgr, Parent) ->
+    event(extend_begin, EventMgr),
+    event(add_tasks, Vertices, EventMgr),
+    event(add_dependencies, Edges, EventMgr),
+    Ret = task_graph_digraph:expand(G, NewTasks, Parent),
+    event(extend_end, EventMgr),
+    Ret.
+
+event(A, B) ->
+    event(A, undefined, B).
+event(Kind, Data, #state{event_mgr = EventMgr}) ->
+    event(Kind, Data, EventMgr);
+event(Kind, Data, EventMgr) when is_pid(EventMgr) ->
+    gen_event:notify( EventMgr
+                    , #tg_event{ timestamp = erlang:system_time(?tg_timeUnit)
+                               , kind = Kind
+                               , data = Data
+                               }
+                    ).
+
+complete_graph(State = #state{parent = Pid, failed_tasks = Failed}) ->
+    %% Assert:
+    #{} = State#state.current_tasks,
+    Result = case is_success(State) of
+                 true ->
+                     {ok, Failed};
+                 false ->
+                     {error, Failed}
+             end,
+    event(graph_complete, [self(), Result], State),
+    Pid ! {result, self(), Result},
+    {stop, normal, State}.
+
+is_success(State) ->
+    maps:size(State#state.failed_tasks) == 0.
+
+is_complete(State) ->
+    maps:size(State#state.current_tasks) == 0.
+
+push_error(Ref, Error, State) ->
+    OldFailedTasks = State#state.failed_tasks,
+    OldCurrentTasks = State#state.current_tasks,
+    event(task_failed, [Ref, Error], State),
+    State#state{ failed_tasks = OldFailedTasks#{Ref => Error}
+               , current_tasks = maps:remove(Ref, OldCurrentTasks)
+               }.
+
+maybe_pop_tasks() ->
+    gen_server:cast(self(), maybe_pop_tasks).
+
+-spec complete_task( pid()
+                   , task_graph:task_id()
+                   , boolean()
+                   , boolean()
+                   , term()
+                   , task_graph:digraph()
+                   ) -> ok.
+complete_task(Parent, Ref, Success, Changed, Return, NewTasks) ->
+    gen_server:cast(Parent, {complete_task, Ref, Success, Changed, Return, NewTasks}).
+
+-spec complete_task(pid(), task_graph:task_id(), boolean(), boolean(), term()) -> ok.
+complete_task(Parent, Ref, Success, Changed, Return) ->
+    complete_task(Parent, Ref, Success, Changed, Return, {[], []}).
+
+-spec defer_task(pid(), task_graph:task_id(), task_graph:digraph()) -> ok.
+defer_task(Parent, Ref, NewTasks) ->
+    gen_server:cast(Parent, {defer_task, Ref, NewTasks}).
+
+-spec run_task({task_graph:task(), boolean()}, #state{}) -> #state{}.
+run_task( {Task = #tg_task{id = Ref}, DepsUnchanged}
+        , State = #state{ current_tasks = TT
+                        , graph = G
+                        , guards = Guards
+                        }) ->
+    GetDepResult = fun(Ref1) ->
+                           task_graph_digraph:get_task_result(G, Ref1)
+                   end,
+    Pid = spawn_task( Task
+                    , State#state.event_mgr
+                    , GetDepResult
+                    , DepsUnchanged andalso Guards
+                    ),
+    State#state{current_tasks = TT#{Ref => Pid}}.
+
+-spec spawn_task( task_graph:task()
+                , event_mgr()
+                , fun((task_graph:task_id()) -> {ok, term()} | error)
+                , boolean()
+                ) -> pid().
+spawn_task( Task = #tg_task{ id = Ref
+                           , execute = Exec
+                           }
+          , EventMgr
+          , GetDepResult
+          , DepsUnchanged
+          ) ->
+    Parent = self(),
+    case Exec of
+        _ when is_atom(Exec) ->
+            RunTaskFun = fun Exec:run_task/3,
+            GuardFun   = fun Exec:guard/3;
+        _ when is_function(Exec) ->
+            RunTaskFun = Exec,
+            GuardFun   = fun(_, _, _) -> changed end;
+        {RunTaskFun, GuardFun} when is_function(RunTaskFun)
+                                  , is_function(GuardFun) ->
+            ok;
+        _ ->
+            RunTaskFun = undefined, %% D'oh!
+            GuardFun = undefined,
+            error({badtask, Exec})
+    end,
+    spawn_link(
+      fun() ->
+              try
+                  Unchanged = DepsUnchanged andalso do_run_guard( Parent
+                                                                , EventMgr
+                                                                , GuardFun
+                                                                , Task
+                                                                , GetDepResult
+                                                                ),
+                  if Unchanged ->
+                          ok;
+                     true ->
+                          do_run_task( Parent
+                                     , EventMgr
+                                     , RunTaskFun
+                                     , Task
+                                     , GetDepResult
+                                     )
+                  end
+              catch
+                  _:Err ?BIND_STACKTRACE(Stack) ->
+                      ?GET_STACKTRACE(Stack),
+                      complete_task( Parent
+                                   , Ref
+                                   , _success = false
+                                   , _changed = true
+                                   , {uncaught_exception, Err, Stack}
+                                   )
+              end
+      end).
+
+-spec do_run_guard( pid()
+                  , pid()
+                  , fun()
+                  , task_graph:task()
+                  , task_runner:get_deps_result()
+                  ) -> boolean().
+do_run_guard( Parent
+            , EventMgr
+            , GuardFun
+            , #tg_task{ id = Ref
+                      , data = Data
+                      }
+            , GetDepResult
+            ) ->
+    event(run_guard, Ref, EventMgr),
+    Result = GuardFun(Ref, Data, GetDepResult),
+    event(guard_complete, Ref, EventMgr),
+    case Result of
+        unchanged ->
+            complete_task(Parent, Ref, true, false, undefined),
+            true;
+        {unchanged, Return} ->
+            complete_task(Parent, Ref, true, false, Return),
+            true;
+        changed ->
+            false
+    end.
+
+-spec do_run_task( pid()
+                 , pid()
+                 , fun()
+                 , task_graph:task()
+                 , task_runner:get_deps_result()
+                 ) -> ok.
+do_run_task( Parent
+           , EventMgr
+           , RunTaskFun
+           , #tg_task{ id = Ref
+                     , data = Data
+                     }
+           , GetDepResult
+           ) ->
+    event(spawn_task, Ref, EventMgr),
+    Return = RunTaskFun(Ref, Data, GetDepResult),
+    case Return of
+        ok ->
+            complete_task( Parent
+                         , Ref
+                         , _success = true
+                         , _changed = true
+                         , undefined
+                         );
+        {ok, Result} ->
+            complete_task( Parent
+                         , Ref
+                         , _success = true
+                         , _changed = true
+                         , Result
+                         );
+        {ok, Result, NewTasks} ->
+            complete_task( Parent
+                         , Ref
+                         , _success = true
+                         , _changed = true
+                         , Result
+                         , NewTasks
+                         );
+
+        {defer, NewTasks} ->
+            defer_task(Parent, Ref, NewTasks);
+
+        {error, Reason} ->
+            complete_task( Parent
+                         , Ref
+                         , _success = false
+                         , _changed = true
+                         , Reason
+                         )
+    end.


### PR DESCRIPTION
Cleaned up task_graph.erl, the interface module. gen_server callbacks
have been moved to task_graph_server.erl. task_graph_lib was renamed to
task_graph_digraph. Removed mentions of workers